### PR TITLE
fix: require 'ostruct' to ensure OpenStruct is available in minimal Ruby environments

### DIFF
--- a/lib/ruby-openai-swarm/core.rb
+++ b/lib/ruby-openai-swarm/core.rb
@@ -1,4 +1,5 @@
 require 'ruby/openai'
+require 'ostruct'
 begin
   require 'pry'
 rescue LoadError

--- a/lib/ruby-openai-swarm/version.rb
+++ b/lib/ruby-openai-swarm/version.rb
@@ -1,3 +1,3 @@
 module OpenAISwarm
-  VERSION = "0.4.0.1"
+  VERSION = "0.4.0.2"
 end

--- a/ruby-openai-swarm.gemspec
+++ b/ruby-openai-swarm.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
   spec.add_dependency "ruby-openai", "~> 7.3"
+  spec.add_dependency "ostruct"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
fix: require 'ostruct' to ensure OpenStruct is available in minimal Ruby environments

Error: uninitialized constant OpenAISwarm::Core::OpenStruct (NameError)

Some Ruby environments don't include 'ostruct' by default, as it's part of the standard library but not preloaded. Explicitly requiring it resolves the above error.